### PR TITLE
Add ncodeunits

### DIFF
--- a/src/FilePathsBase.jl
+++ b/src/FilePathsBase.jl
@@ -66,6 +66,7 @@ abstract type AbstractPath <: AbstractString end
 
 # Required methods for subtype of AbstractString
 Compat.lastindex(p::AbstractPath) = lastindex(String(p))
+Compat.ncodeunits(p::AbstractPath) = ncodeunits(String(p))
 if VERSION >= v"0.7-"
     Base.iterate(p::AbstractPath) = iterate(String(p))
     Base.iterate(p::AbstractPath, state::Int) = iterate(String(p), state)


### PR DESCRIPTION
Calls to `checkbounds` that can happen in other scenarios will fail unless `ncodeunits` is defined.