### PR TITLE
Restrict all Path tuples to `Vararg{String}`

### DIFF
--- a/src/path.jl
+++ b/src/path.jl
@@ -9,8 +9,9 @@ Responsible for creating the appropriate platform specific path
 """
 Path() = @static Compat.Sys.isunix() ? PosixPath() : WindowsPath()
 Path(path::AbstractPath) = path
-Path(pieces::Tuple) = @static Compat.Sys.isunix() ? PosixPath(pieces) : WindowsPath(pieces)
 Path(str::AbstractString) = @static Compat.Sys.isunix() ? PosixPath(str) : WindowsPath(str)
+Path(pieces::Tuple{Vararg{String}}) = 
+    @static Compat.Sys.isunix() ? PosixPath(pieces) : WindowsPath(pieces)
 
 """
     @p_str -> Path

--- a/src/posix.jl
+++ b/src/posix.jl
@@ -1,5 +1,5 @@
 struct PosixPath <: AbstractPath
-    parts::Tuple
+    parts::Tuple{Vararg{String}}
 end
 
 PosixPath() = PosixPath(tuple())


### PR DESCRIPTION
Closes #7 