### PR TITLE
Added a path types registry.

### DIFF
--- a/src/FilePathsBase.jl
+++ b/src/FilePathsBase.jl
@@ -62,7 +62,21 @@ else
     export isexecutable
 end
 
+const PATH_TYPES = DataType[]
+
+function __init__()
+    register(PosixPath)
+    register(WindowsPath)
+end
+
 abstract type AbstractPath <: AbstractString end
+
+function register(T::Type{<:AbstractPath})
+    # We add the type to the beginning of our PATH_TYPES, 
+    # so that they can take precedence over the Posix and 
+    # Windows paths.
+    Compat.pushfirst!(PATH_TYPES, T)
+end
 
 # Required methods for subtype of AbstractString
 Compat.lastindex(p::AbstractPath) = lastindex(String(p))
@@ -81,6 +95,7 @@ root(path::AbstractPath) = error("`root` not implemented.")
 drive(path::AbstractPath) = error("`drive` not implemented.")
 
 Base.convert(::Type{AbstractPath}, x::AbstractString) = Path(x)
+ispathtype(::Type{T}, x::AbstractString) where {T<:AbstractPath} = false
 
 include("constants.jl")
 include("utils.jl")

--- a/src/path.jl
+++ b/src/path.jl
@@ -9,9 +9,24 @@ Responsible for creating the appropriate platform specific path
 """
 Path() = @static Compat.Sys.isunix() ? PosixPath() : WindowsPath()
 Path(path::AbstractPath) = path
-Path(str::AbstractString) = @static Compat.Sys.isunix() ? PosixPath(str) : WindowsPath(str)
-Path(pieces::Tuple{Vararg{String}}) = 
+Path(pieces::Tuple{Vararg{String}}) =
     @static Compat.Sys.isunix() ? PosixPath(pieces) : WindowsPath(pieces)
+
+# May want to support using the registry for other constructors as well
+function Path(str::AbstractString; debug=false)
+    types = filter(t -> ispathtype(t, str), PATH_TYPES)
+
+    if length(types) > 1
+        Compat.@debug(
+            string(
+                "Found multiple path types that match the string specified ($types). ",
+                "Please use a specific constructor if $(first(types)) is not the correct type."
+            )
+        )
+    end
+
+    return first(types)(str)
+end
 
 """
     @p_str -> Path

--- a/src/posix.jl
+++ b/src/posix.jl
@@ -22,6 +22,7 @@ end
 ==(a::PosixPath, b::PosixPath) = parts(a) == parts(b)
 Base.String(path::PosixPath) = joinpath(parts(path)...)
 parts(path::PosixPath) = path.parts
+ispathtype(::Type{PosixPath}, str::AbstractString) = Compat.Sys.isunix()
 
 Base.show(io::IO, path::PosixPath) = print(io, "p\"$(join(parts(path), '/'))\"")
 

--- a/src/windows.jl
+++ b/src/windows.jl
@@ -71,6 +71,7 @@ Base.String(path::WindowsPath) = joinpath(parts(path)...)
 parts(path::WindowsPath) = path.parts
 drive(path::WindowsPath) = path.drive
 root(path::WindowsPath) = path.root
+ispathtype(::Type{WindowsPath}, str::AbstractString) = Compat.Sys.iswindows()
 
 function Base.show(io::IO, path::WindowsPath)
     print(io, "p\"")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,9 +3,13 @@ using FilePathsBase
 using Compat.LinearAlgebra
 using Compat.Test
 
+include("testpaths.jl")
+
 @testset "FilePathsBase" begin
+    include("mode.jl")
+    include("path.jl")
 
-include("mode.jl")
-include("path.jl")
-
+    # Test that our weird registered path works
+    path = p"test|;;my;weird;test;path"
+    @test path.parts == ("test|", "", "my", "weird", "test", "path")
 end

--- a/test/testpaths.jl
+++ b/test/testpaths.jl
@@ -1,0 +1,36 @@
+module TestPaths
+
+using FilePathsBase
+
+import Base: ==
+
+__init__() = FilePathsBase.register(TestPath)
+
+# We'll make a semicolon separate test path
+struct TestPath <: AbstractPath
+    parts::Tuple{Vararg{String}}
+end
+
+TestPath() = TestPath(tuple())
+
+function TestPath(str::AbstractString)
+    str = String(str)
+
+    if isempty(str)
+        return TestPath(tuple("."))
+    end
+
+    tokenized = split(str, ";")
+    if isempty(tokenized[1])
+        tokenized[1] = ";"
+    end
+    return TestPath(tuple(map(String, tokenized)...))
+end
+
+==(a::TestPath, b::TestPath) = a.parts == b.parts
+Base.String(path::TestPath) = join([path.parts...], ";")
+FilePathsBase.ispathtype(::Type{TestPath}, str::AbstractString) = startswith(str, "test|;;")
+Base.show(io::IO, path::TestPath) = print(io, "p\"$path\"")
+
+
+end


### PR DESCRIPTION
The generally idea is that other packages should be able to register their custom path types with
FilePathsBase to hook into the `Path` and `p_str` interface.
Currently, libraries will need to run `FilePathsBase.register(MyPath)` in their `__init__()` function
and define an `ispathtype(::Type{MyType}, str)` method which checks to see if `str` matches their path syntax.
PosixPath and WindowsPath will still be the fallbacks for `Path` and `p_str`.

Use cases:

- `p"s3://mybucket/path/to/my/file.tar.gz"` -> S3Path
- `p"nfs://server/remote/system/file.jl"` -> NFSPath
- `p"\\hostname\sharename\path\to\my\file.txt"` -> UNCPath

Closes https://github.com/rofinn/FilePaths.jl/issues/30