### PR TITLE
Undeprecate joinpath

### DIFF
--- a/src/deprecates.jl
+++ b/src/deprecates.jl
@@ -1,7 +1,6 @@
 import Base.@deprecate
 
 import Base:
-    joinpath,
     dirname,
     ispath,
     realpath,
@@ -14,7 +13,6 @@ import Base:
     mv,
     rm
 
-@deprecate joinpath(root::AbstractPath, pieces::Union{AbstractPath, AbstractString}...) join(root, pieces...)
 @deprecate dirname(path::AbstractPath) parent(path)
 @deprecate ispath(path::AbstractPath) exists(path)
 @deprecate realpath(path::AbstractPath) real(path)

--- a/src/path.jl
+++ b/src/path.jl
@@ -166,6 +166,10 @@ function Base.join(root::AbstractPath, pieces::Union{AbstractPath, AbstractStrin
     return Path(tuple(all_parts...))
 end
 
+function Base.joinpath(root::AbstractPath, pieces::Union{AbstractPath, AbstractString}...)
+    return join(root, pieces...)
+end
+
 Base.basename(path::AbstractPath) = parts(path)[end]
 
 """

--- a/test/path.jl
+++ b/test/path.jl
@@ -19,6 +19,7 @@ cd(abs(parent(Path(@__FILE__)))) do
 
         @test basename(p) == "FilePathsBase.jl"
         @test join(parent(p), Path(basename(p))) == p
+        @test joinpath(parent(p), Path(basename(p))) == p
         @test filename(p) == "FilePathsBase"
 
         @test extension(p) == "jl"
@@ -84,6 +85,7 @@ cd(abs(parent(Path(@__FILE__)))) do
         @test @__PATH__() == Path(@__DIR__)
         @test @__FILEPATH__() == Path(@__FILE__)
         @test FilePathsBase.@LOCAL("foo.txt") == join(@__PATH__, "foo.txt")
+        @test FilePathsBase.@LOCAL("foo.txt") == joinpath(@__PATH__, "foo.txt")
     end
 end
 


### PR DESCRIPTION
For now, as `join` on paths could be confused with string `join`, since a path is an `AbstractString`.