### PR TITLE
Fix makepath deprecation to ignore existing directories (closes #26)

### DIFF
--- a/src/deprecates.jl
+++ b/src/deprecates.jl
@@ -21,6 +21,6 @@ import Base:
 @deprecate relpath(path::AbstractPath) relative(path)
 @deprecate filemode(path::AbstractPath) mode(path)
 @deprecate isabspath(path::AbstractPath) isabs(path)
-@deprecate mkpath(path::AbstractPath) mkdir(path; recursive=true)
+@deprecate mkpath(path::AbstractPath) mkdir(path; recursive=true, exist_ok=true)
 @deprecate mv(src::AbstractPath, dest::AbstractPath; kwargs...) move(src, dest; kwargs...)
 @deprecate rm(path::AbstractPath; kwargs...) remove(path; kwargs...)


### PR DESCRIPTION
I didn't know this option existed, I should have done this months ago