### PR TITLE
Use properties rather than accessors

### DIFF
--- a/src/FilePathsBase.jl
+++ b/src/FilePathsBase.jl
@@ -19,12 +19,8 @@ export
     Status,
 
     # Methods
-    anchor,
     cwd,
-    drive,
     home,
-    components,
-    root,
     hasparent,
     parents,
     filename,
@@ -76,13 +72,16 @@ end
 """
     AbstractPath
 
-Defines an abstract filesystem path. Subtypes of `AbstractPath` should implement the
-following methods:
+Defines an abstract filesystem path. Subtypes of `AbstractPath` should have the following
+fields:
 
+- fp.segments   # tuple of path segments
+- fp.root       # fs root (defaults to "/")
+- fp.drive      # fs drive (defaults to "")
+- fp.separator  # symbol for separating path segments (defaults to "/")
+
+And the following methods defined
 - `Base.print(io, p)` (default: call base julia's joinpath with drive and path parts)
-- `FilePathsBase.path(p)`
-- `FilePathsBase.root(p)`
-- `FilePathsBase.drive(p)`
 - `FilePathsBase.ispathtype(::Type{MyPath}, x::AbstractString) = true`
 """
 abstract type AbstractPath end  # Define the AbstractPath here to avoid circular include dependencies

--- a/src/deprecates.jl
+++ b/src/deprecates.jl
@@ -24,3 +24,7 @@ import Base:
 @deprecate mkpath(fp::AbstractPath) mkdir(fp; recursive=true, exist_ok=true)
 @deprecate mv(src::AbstractPath, dest::AbstractPath; kwargs...) move(src, dest; kwargs...)
 @deprecate rm(fp::AbstractPath; kwargs...) remove(fp; kwargs...)
+@deprecate parts(fp::AbstractPath) fp.segments
+@deprecate drive(fp::Abstractpath) fp.drive
+@deprecate root(fp::AbstractPath) fp.root
+@deprecate anchor(fp::AbstractPath) fp.anchor

--- a/src/deprecates.jl
+++ b/src/deprecates.jl
@@ -22,8 +22,6 @@ import Base:
 @deprecate filemode(fp::AbstractPath) mode(fp)
 @deprecate isabspath(fp::AbstractPath) isabs(fp)
 @deprecate mkpath(fp::AbstractPath) mkdir(fp; recursive=true, exist_ok=true)
-@deprecate mv(src::AbstractPath, dest::AbstractPath; kwargs...) move(src, dest; kwargs...)
-@deprecate rm(fp::AbstractPath; kwargs...) remove(fp; kwargs...)
 @deprecate parts(fp::AbstractPath) fp.segments
 @deprecate drive(fp::Abstractpath) fp.drive
 @deprecate root(fp::AbstractPath) fp.root

--- a/src/libc.jl
+++ b/src/libc.jl
@@ -48,16 +48,16 @@ struct User
     gid::UInt64
     dir::String
     shell::String
+end
 
-    function User(ps::Cpasswd)
-        new(
-            unsafe_string(ps.pw_name),
-            UInt64(ps.pw_uid),
-            UInt64(ps.pw_gid),
-            unsafe_string(ps.pw_dir),
-            unsafe_string(ps.pw_shell)
-        )
-    end
+function User(ps::Cpasswd)
+    User(
+        unsafe_string(ps.pw_name),
+        UInt64(ps.pw_uid),
+        UInt64(ps.pw_gid),
+        unsafe_string(ps.pw_dir),
+        unsafe_string(ps.pw_shell)
+    )
 end
 
 User(passwd::Ptr{Cpasswd}) = User(unsafe_load(passwd))
@@ -94,10 +94,9 @@ end
 struct Group
     name::String
     gid::UInt64
-
-    Group(gr::Cgroup) = new(unsafe_string(gr.gr_name), UInt64(gr.gr_gid))
 end
 
+Group(gr::Cgroup) = Group(unsafe_string(gr.gr_name), UInt64(gr.gr_gid))
 Group(group::Ptr{Cgroup}) = Group(unsafe_load(group))
 
 function Base.show(io::IO, group::Group)

--- a/src/posix.jl
+++ b/src/posix.jl
@@ -1,19 +1,9 @@
 struct PosixPath <: AbstractPath
-    path::Tuple{Vararg{String}}
+    segments::Tuple{Vararg{String}}
     root::String
 end
 
 PosixPath() = PosixPath(tuple(), "")
-
-function PosixPath(components::Tuple)
-    components = map(String, Iterators.filter(!isempty, components))
-
-    if components[1]==POSIX_PATH_SEPARATOR
-        return PosixPath(tuple(components[2:end]...), POSIX_PATH_SEPARATOR)
-    else
-        return PosixPath(tuple(components...), "")
-    end
-end
 
 function PosixPath(str::AbstractString)
     str = string(str)
@@ -30,14 +20,11 @@ function PosixPath(str::AbstractString)
     return PosixPath(tuple(map(String, filter!(!isempty, tokenized))...), root)
 end
 
-path(fp::PosixPath) = fp.path
-root(fp::PosixPath) = fp.root
-drive(fp::PosixPath) = ""
 ispathtype(::Type{PosixPath}, str::AbstractString) = Sys.isunix()
-isabs(fp::PosixPath) = !isempty(root(fp))
+isabs(fp::PosixPath) = !isempty(fp.root)
 
 function Base.expanduser(fp::PosixPath)
-    p = path(fp)
+    p = fp.segments
 
     if p[1] == "~"
         if length(p) > 1

--- a/src/status.jl
+++ b/src/status.jl
@@ -15,23 +15,23 @@ struct Status
     blocks::Int64
     mtime::DateTime
     ctime::DateTime
+end
 
-    function Status(s::StatStruct)
-        new(
-            s.device,
-            s.inode,
-            Mode(s.mode),
-            s.nlink,
-            User(s.uid),
-            Group(s.gid),
-            s.rdev,
-            s.size,
-            s.blksize,
-            s.blocks,
-            unix2datetime(s.mtime),
-            unix2datetime(s.ctime)
-        )
-    end
+function Status(s::StatStruct)
+    Status(
+        s.device,
+        s.inode,
+        Mode(s.mode),
+        s.nlink,
+        User(s.uid),
+        Group(s.gid),
+        s.rdev,
+        s.size,
+        s.blksize,
+        s.blocks,
+        unix2datetime(s.mtime),
+        unix2datetime(s.ctime)
+    )
 end
 
 function Base.show(io::IO, s::Status)

--- a/src/system.jl
+++ b/src/system.jl
@@ -225,17 +225,16 @@ function Base.symlink(src::SystemPath, dest::SystemPath; exist_ok=false, overwri
     end
 end
 
-Base.rm(fp::SystemPath; kwargs...) = rm(string(fp); kwargs...)
+function Base.rm(fp::SystemPath; kwargs...)
+    rm(string(fp); kwargs...)
+end
 Base.touch(fp::SystemPath) = touch(string(fp))
 function mktmp(parent::SystemPath=Path(tempdir()))
     fp, io = mktemp(string(parent))
     return Path(fp), io
 end
 
-function mktmpdir(parent::SystemPath=tmpdir())
-    @show string(parent)
-    Path(mktempdir(string(parent)))
-end
+mktmpdir(parent::SystemPath=tmpdir()) = Path(mktempdir(string(parent)))
 
 """
     chown(fp::SystemPath, user::AbstractString, group::AbstractString; recursive=false)

--- a/src/test.jl
+++ b/src/test.jl
@@ -149,7 +149,7 @@ module TestPaths
 
     function initialize(ps::PathSet)
         @info "Initializing $(typeof(ps))"
-        mkdir.([ps.foo, ps.qux, ps.fred]; recursive=true)
+        mkdir.([ps.foo, ps.qux, ps.fred]; recursive=true, exist_ok=true)
         write(ps.baz, "Hello World!")
         write(ps.quux, "Hello Again!")
 

--- a/src/windows.jl
+++ b/src/windows.jl
@@ -7,7 +7,7 @@ struct WindowsPath <: AbstractPath
     function WindowsPath(
         segments::Tuple, root::String, drive::String, separator::String=WIN_PATH_SEPARATOR
     )
-        return new(Tuple(Iterators.filter(!isempty, path)), root, drive, separator)
+        return new(Tuple(Iterators.filter(!isempty, segments)), root, drive, separator)
     end
 end
 
@@ -76,7 +76,7 @@ function Base.show(io::IO, fp::WindowsPath)
 end
 
 function isabs(fp::WindowsPath)
-    return !isempty(drive(fp)) || !isempty(root(fp))
+    return !isempty(fp.drive) || !isempty(fp.root)
 end
 
 Base.expanduser(fp::WindowsPath) = fp

--- a/src/windows.jl
+++ b/src/windows.jl
@@ -1,10 +1,13 @@
 struct WindowsPath <: AbstractPath
-    path::Tuple{Vararg{String}}
+    segments::Tuple{Vararg{String}}
     root::String
     drive::String
+    separator::String
 
-    function WindowsPath(path::Tuple, root::String, drive::String)
-        return new(Tuple(Iterators.filter(!isempty, path)), root, drive)
+    function WindowsPath(
+        segments::Tuple, root::String, drive::String, separator::String=WIN_PATH_SEPARATOR
+    )
+        return new(Tuple(Iterators.filter(!isempty, path)), root, drive, separator)
     end
 end
 
@@ -14,23 +17,6 @@ function _win_splitdrive(fp::String)
 end
 
 WindowsPath() = WindowsPath(tuple(), "", "")
-
-function WindowsPath(components::Tuple)
-    drive = ""
-    root = ""
-    path = collect(components)
-
-    if occursin(":", first(path))
-        drive, root  = _win_splitdrive(popfirst!(path))
-    end
-
-    if isempty(root) && first(path) == WIN_PATH_SEPARATOR
-        root = WIN_PATH_SEPARATOR
-        popfirst!(path)
-    end
-
-    return WindowsPath(tuple(path...), root, drive)
-end
 
 function WindowsPath(str::AbstractString)
     if isempty(str)
@@ -72,23 +58,20 @@ function WindowsPath(str::AbstractString)
     end
 end
 
-==(a::WindowsPath, b::WindowsPath) = lowercase.(components(a)) == lowercase.(components(b))
-
-path(fp::WindowsPath) = fp.path
-drive(fp::WindowsPath) = fp.drive
-root(fp::WindowsPath) = fp.root
-ispathtype(::Type{WindowsPath}, str::AbstractString) = Sys.iswindows()
-
-function Base.print(io::IO, fp::WindowsPath)
-    print(io, drive(fp) * root(fp) * join(path(fp), WIN_PATH_SEPARATOR))
+function Base.:(==)(a::WindowsPath, b::WindowsPath)
+    return lowercase.(a.segments) == lowercase.(b.segments) &&
+        lowercase(a.root) == lowercase(b.root) &&
+        lowercase(a.drive) == lowercase(b.drive)
 end
+
+ispathtype(::Type{WindowsPath}, str::AbstractString) = Sys.iswindows()
 
 function Base.show(io::IO, fp::WindowsPath)
     print(io, "p\"")
     if isabs(fp)
-        print(io, replace(anchor(fp), "\\" => "/"))
+        print(io, replace(fp.anchor, "\\" => "/"))
     end
-    print(io, join(path(fp), "/"))
+    print(io, join(fp.segments, "/"))
     print(io, "\"")
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -16,8 +16,6 @@ include("testpkg.jl")
         # Test that our weird registered path works
         ps = PathSet(TestPkg.posix2test(tmpdir()) / "pathset_root"; symlink=true)
 
-        @show ps
-
         @testset "$(typeof(ps.root))" begin
             testsets = [
                 test_constructor,


### PR DESCRIPTION
Use properties rather than accessors and add a factory method for `Path(path, segments)`.