### PR TITLE
Adds a fallback download method for when the destination is a string

### DIFF
--- a/src/path.jl
+++ b/src/path.jl
@@ -562,6 +562,11 @@ end
 
 Base.download(url::AbstractPath, localfile::AbstractPath) = cp(url, localfile; force=true)
 
+function Base.download(url::AbstractPath, localfile::AbstractString)
+    download(url, Path(localfile))
+    return localfile
+end
+
 """
     readpath(fp::P) where {P <: AbstractPath} -> Vector{P}
 """

--- a/src/test.jl
+++ b/src/test.jl
@@ -761,7 +761,10 @@ module TestPaths
             download(ps.foo / "README.md", ps.qux / "README.md")
             @test exists(ps.qux / "README.md")
 
-            rm.([ps.foo / "README.md", ps.qux / "README.md"])
+             # Test downloading to a string
+            download(ps.foo / "README.md", string(ps.fred / "README.md"))
+            @test exists(ps.fred / "README.md")
+            rm.([ps.foo / "README.md", ps.qux / "README.md", ps.fred / "README.md"])
         end
     end
 


### PR DESCRIPTION
Attempts to address https://github.com/oxinabox/DataDeps.jl/issues/100