### PR TITLE
Fix sync to always respect walkpath order.

### DIFF
--- a/src/test.jl
+++ b/src/test.jl
@@ -640,6 +640,29 @@ module TestPaths
             sync(ps.foo, ps.qux / "foo"; delete=true)
             @test !exists(ps.qux / "foo" / "test.txt")
             rm(ps.qux / "foo"; recursive=true)
+
+            # Test a condtion where the index could reorder the walkpath order.
+            tmp_src = ps.root / "tmp-src"
+            mkdir(tmp_src)
+            src_file = tmp_src / "file1"
+            write(src_file, "Hello World!")
+
+            src_folder = tmp_src / "folder1"
+            mkdir(src_folder)
+            src_folder_file = src_folder / "file2"
+            write(src_folder_file, "") # empty file
+
+            src_folder2 = src_folder / "folder2"  # nested folders
+            mkdir(src_folder2)
+            src_folder2_file = src_folder2 / "file3"
+            write(src_folder2_file, "Test")
+
+            tmp_dst = ps.root / "tmp_dst"
+            mkdir(tmp_dst)
+            sync(tmp_src, tmp_dst)
+            @test exists(tmp_dst / "folder1" / "folder2" / "file3")
+            rm(tmp_src; recursive=true)
+            rm(tmp_dst; recursive=true)
         end
     end
 


### PR DESCRIPTION
Specifically, we could run into issues where a parent doesn't exist yet when copying files.

```
julia> index = Dict(Tuple(setdiff(p.segments, src.segments)) => p for p in walkpath(src))
Dict{Tuple{String,Vararg{String,N} where N},PosixPath} with 5 entries:
  ("folder1", "folder2")          => /var/folders/h_/vkjv56410m7f75g9ffp46mf80000gp/T/tmpcJbzPa/folder1/folder2
  ("folder1",)                    => /var/folders/h_/vkjv56410m7f75g9ffp46mf80000gp/T/tmpcJbzPa/folder1
  ("folder1", "file2")            => /var/folders/h_/vkjv56410m7f75g9ffp46mf80000gp/T/tmpcJbzPa/folder1/file2
  ("folder1", "folder2", "file3") => /var/folders/h_/vkjv56410m7f75g9ffp46mf80000gp/T/tmpcJbzPa/folder1/folder2/file3
  ("file1",)                      => /var/folders/h_/vkjv56410m7f75g9ffp46mf80000gp/T/tmpcJbzPa/file1
```

This would try and copy folder1/folder2 before creating folder1 because of how the segments were hashed.
An OrderedDict would also resolve this, but we don't want to depend on external dependencies in FilePathsBase.