### PR TITLE
Fix a couple of bugs, add contractuser for PosixPath

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+Manifest.toml

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "FilePathsBase"
 uuid = "48062228-2e41-5def-b9a4-89aafe57970f"
 authors = ["Rory Finnegan"]
-version = "0.6.2"
+version = "0.7.0"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ splitdrive()[1] | drive
 N/A | root (property)
 split(p, "/") | segments (property)
 expanduser | expanduser
+Base.Filesystem.contractuser | Base.Filesystem.contractuser
 mkdir | mkdir
 mkpath | N/A (use mkdir)
 symlink | symlink

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -133,6 +133,7 @@ splitdrive()[1] | drive
 N/A | root (property)
 split(p, "/") | segments (property)
 expanduser | expanduser
+Base.Filesystem.contractuser | Base.Filesystem.contractuser
 mkdir | mkdir
 mkpath | N/A (use mkdir)
 symlink | symlink

--- a/src/path.jl
+++ b/src/path.jl
@@ -103,6 +103,7 @@ p"/home/JuliaUser/Projects/julia"
 cwd() = Path(pwd())
 home() = Path(homedir())
 Base.expanduser(fp::AbstractPath) = fp
+Base.Filesystem.contractuser(fp::AbstractPath) = fp
 
 # components(fp::AbstractPath) = tuple(drive(fp), root(fp), path(fp)...)
 

--- a/src/path.jl
+++ b/src/path.jl
@@ -168,7 +168,7 @@ julia> parents(p"etc")
 julia> parents(p".")
 1-element Array{PosixPath,1}:
  p"."
- ```
+```
 """
 function parents(fp::T) where {T <: AbstractPath}
     if hasparent(fp)

--- a/src/posix.jl
+++ b/src/posix.jl
@@ -16,7 +16,7 @@ function PosixPath(str::AbstractString)
     root = ""
 
     if isempty(str)
-        return PosixPath(tuple("."))
+        return PosixPath(tuple("."), "")
     end
 
     tokenized = split(str, POSIX_PATH_SEPARATOR)
@@ -34,9 +34,9 @@ function Base.expanduser(fp::PosixPath)
 
     if p[1] == "~"
         if length(p) > 1
-            return PosixPath(tuple(homedir(), p[2:end]...))
+            return PosixPath(joinpath(homedir(), p[2:end]...))
         else
-            return PosixPath(tuple(homedir()))
+            return PosixPath(homedir())
         end
     end
 

--- a/src/posix.jl
+++ b/src/posix.jl
@@ -42,3 +42,14 @@ function Base.expanduser(fp::PosixPath)
 
     return fp
 end
+
+function Base.Filesystem.contractuser(fp::PosixPath)
+    h = homedir()
+    str = string(fp)
+
+    if startswith(str, h)
+        return PosixPath(replace(str, h => "~"; count=1))
+    end
+
+    return fp
+end


### PR DESCRIPTION
Implements `Base.Filesystem.contractuser` which goes from `/home/user/foo` to `~/foo` on Unix.

I'm not sure if I've implemented/fixed this stuff in the most efficient way (via the string constructor), if there's a better way please let me know.

I should probably add some tests for `contractuser` as well as the bugs that were fixed! 

Also FYI, the `chown` tests don't work on all systems. On Arch Linux it seems that I don't have the required group or user:

```jl
chown: invalid group: ‘nobody:nogroup’
chown: Test Failed at /home/degraafc/code/FilePathsBase/src/test.jl:781
  Expression: chown(newfile, "nobody", "nogroup"; recursive=true)
    Expected: ErrorException
      Thrown: ProcessFailedException
Stacktrace:
 [1] macro expansion at /home/degraafc/code/FilePathsBase/src/test.jl:781 [inlined]
 [2] macro expansion at /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.2/Test/src/Test.jl:1113 [inlined]
 [3] test_chown(::PathSet{PosixPath}) at /home/degraafc/code/FilePathsBase/src/test.jl:774
[ Info: Initializing PathSet{Main.TestPkg.TestPath}
chown: invalid group: ‘nobody:nogroup’
chown: Test Failed at /home/degraafc/code/FilePathsBase/src/test.jl:781
  Expression: chown(newfile, "nobody", "nogroup"; recursive=true)
    Expected: ErrorException
      Thrown: ProcessFailedException
Stacktrace:
 [1] macro expansion at /home/degraafc/code/FilePathsBase/src/test.jl:781 [inlined]
 [2] macro expansion at /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.2/Test/src/Test.jl:1113 [inlined]
 [3] test_chown(::PathSet{Main.TestPkg.TestPath}) at /home/degraafc/code/FilePathsBase/src/test.jl:774
```