### PR TITLE
Cleanup parent behaviour to include root path when applicable

### DIFF
--- a/src/FilePathsBase.jl
+++ b/src/FilePathsBase.jl
@@ -33,6 +33,7 @@ export
     created,
     modified,
     relative,
+    isrelative,
     ismount,
     islink,
     cp,

--- a/src/path.jl
+++ b/src/path.jl
@@ -107,6 +107,8 @@ Base.broadcastable(fp::AbstractPath) = Ref(fp)
 
 # components(fp::AbstractPath) = tuple(drive(fp), root(fp), path(fp)...)
 
+isrelative(fp::AbstractPath) = isempty(fp.root)
+
 #=
 Path Modifiers
 ===============================================
@@ -118,7 +120,7 @@ path components
 
 Returns whether there is a parent directory component to the supplied path.
 """
-hasparent(fp::AbstractPath) = length(fp.segments) > Int(isempty(fp.root))
+hasparent(fp::AbstractPath) = length(fp.segments) > isrelative(fp)
 
 """
     parent{T<:AbstractPath}(fp::T) -> T
@@ -173,10 +175,9 @@ julia> parents(p".")
 """
 function parents(fp::T) where {T <: AbstractPath}
     if hasparent(fp)
-        # If we have a root then include that in the returned paths
-        # j = 1 when fp.root is empty and 0 otherwise
-        j = Int(isempty(fp.root))
-        return [Path(fp, fp.segments[1:i]) for i in j:length(fp.segments)-1]
+        # Iterate from 1:n-1 or 0:n-1 for relative and absolute paths respectively.
+        # (i.e., include fp.root when applicable)
+        return [Path(fp, fp.segments[1:i]) for i in isrelative(fp):length(fp.segments) - 1]
     elseif fp.segments == tuple(".") || !isempty(fp.root)
         return [fp]
     else

--- a/src/path.jl
+++ b/src/path.jl
@@ -118,7 +118,7 @@ path components
 
 Returns whether there is a parent directory component to the supplied path.
 """
-hasparent(fp::AbstractPath) = length(fp.segments) > 1
+hasparent(fp::AbstractPath) = length(fp.segments) > Int(isempty(fp.root))
 
 """
     parent{T<:AbstractPath}(fp::T) -> T
@@ -173,11 +173,14 @@ julia> parents(p".")
 """
 function parents(fp::T) where {T <: AbstractPath}
     if hasparent(fp)
-        return [Path(fp, fp.segments[1:i]) for i in 1:length(fp.segments)-1]
-    elseif fp.segments == tuple(".") || isempty(fp.segments)
+        # If we have a root then include that in the returned paths
+        # j = 1 when fp.root is empty and 0 otherwise
+        j = Int(isempty(fp.root))
+        return [Path(fp, fp.segments[1:i]) for i in j:length(fp.segments)-1]
+    elseif fp.segments == tuple(".") || !isempty(fp.root)
         return [fp]
     else
-        return [isempty(fp.root) ? Path(fp, tuple(".")) : Path(fp, ())]
+        return [Path(fp, tuple("."))]
     end
 end
 

--- a/src/path.jl
+++ b/src/path.jl
@@ -107,6 +107,11 @@ Base.broadcastable(fp::AbstractPath) = Ref(fp)
 
 # components(fp::AbstractPath) = tuple(drive(fp), root(fp), path(fp)...)
 
+"""
+    isrelative(fp::AbstractPath) -> Bool
+
+Returns true if `fp.root` is empty, indicating that it is a relative path.
+"""
 isrelative(fp::AbstractPath) = isempty(fp.root)
 
 #=

--- a/test/buffer.jl
+++ b/test/buffer.jl
@@ -50,12 +50,12 @@ using FilePathsBase: FileBuffer
     end
 
     @testset "Custom Types" begin
-        jlso = JLSOFile("msg" => "Hello World!")
+        jlso = JLSOFile(:msg => "Hello World!")
         mktmpdir() do d
             cd(d) do
                 write(p"hello_world.jlso", jlso)
                 new_jlso = read(p"hello_world.jlso", JLSOFile)
-                @test new_jlso["msg"] == "Hello World!"
+                @test new_jlso[:msg] == "Hello World!"
 
                 rm(p"hello_world.jlso")
                 data = IOBuffer()
@@ -76,7 +76,7 @@ using FilePathsBase: FileBuffer
                     end
 
                     new_jlso = read(IOBuffer(data), JLSOFile)
-                    @test new_jlso["msg"] == "Hello World!"
+                    @test new_jlso[:msg] == "Hello World!"
                 end
             end
         end


### PR DESCRIPTION
Primary behaviour changes:

1. `parents(cwd())` includes the root if applicable (e.g., it isn't empty).
2. hasparent(p"/foo") returns true because the root is the parent.

NOTE: This aligns with pathlib to support @oxinabox's desire for `parent(fp) === fp` when there are no parents. I think I'd prefer the `rust` approach of returning `nothing`, but that would differ from the `Base.parent` behaviour for arrays.