### PR TITLE
Add indexing and iteration support to the AbstractPath type

### DIFF
--- a/src/path.jl
+++ b/src/path.jl
@@ -114,6 +114,16 @@ Returns true if `fp.root` is empty, indicating that it is a relative path.
 """
 isrelative(fp::AbstractPath) = isempty(fp.root)
 
+# Support immutable indexing API
+Base.getindex(fp::AbstractPath, idx) = fp.segments[idx]
+Base.firstindex(::AbstractPath) = 1
+Base.lastindex(fp::AbstractPath) = length(fp)
+
+# Support iteration protocol
+Base.eltype(::AbstractPath) = String
+Base.length(fp::AbstractPath) = length(fp.segments)
+Base.iterate(fp::AbstractPath, state=1) = iterate(fp.segments, state)
+
 #=
 Path Modifiers
 ===============================================

--- a/src/test.jl
+++ b/src/test.jl
@@ -73,6 +73,8 @@ module TestPaths
         test_parse,
         test_convert,
         test_components,
+        test_indexing,
+        test_iteration,
         test_parents,
         test_descendants_and_ascendants,
         test_join,
@@ -118,61 +120,6 @@ module TestPaths
         test_chmod,
         test_download
 
-    # foo, bar, baz, qux, quux, quuz, corge, grault, garply, waldo, fred, plugh, xyzzy, and thud
-    #=
-    To Test:
-
-    - [X] Construction (T, Path, p"...")
-    - [X] show, parse, convert
-    - [X] anchor, drive, root
-    - [X] hasparent
-    - [X] parent
-    - [X] parents
-    - [X] *, /, join
-    - [X] basename
-    - [X] filename
-    - [X] isempty
-    - [X] norm
-    - [X] abs?
-    - [X] relative?
-    - [X] exists
-    - [X] real
-    - [X] stat/lstat
-    - [X] size (could this default to using a FileBuffer?)
-    - [X] modified
-    - [X] created
-    - [X] modified
-    - [X] created
-    - [X] issocket
-    - [X] isfifo
-    - [X] ischardev
-    - [X] isblockdev
-    - [X] ismount
-    - [X] isdir
-    - [X] isfile
-    - [X] isexecutable
-    - [X] iswritable
-    - [X] isreadable
-    - [X] cd?
-    - [X] mkdir
-    - [X] rm
-    - [X] read
-    - [X] write
-    - [X] cp
-    - [X] mv
-    - [X] symlink
-    - [X] touch
-    - [X] tmpname
-    - [X] tmpdir
-    - [X] mktmp
-    - [X] mktmpdir
-    - [X] readpath
-    - [X] walkpath
-    - [X] open
-    - [X] chmod
-    - [X] chown
-    - [X] download
-    =#
     """
         PathSet(root::AbstractPath=tmpdir(); symlink=false)
 
@@ -285,6 +232,23 @@ module TestPaths
             @test ps.bar < ps.foo
             @test sort([ps.foo, ps.bar, ps.fred]) == [ps.bar, ps.foo, ps.fred]
         end
+    end
+
+    function test_indexing(ps::PathSet)
+        @test firstindex(ps.root) == 1
+        @test lastindex(ps.root) == length(ps.root.segments)
+        # `begin` indexing was only added in 1.4, so we'll leave this test commented
+        # out for now as there isn't a compat for that syntax.
+        # @test ps.root[begin] == ps.root.segments[1]
+        @test ps.baz[end] == "baz.txt"
+        @test ps.quux[end-2:end] == ("bar", "qux", "quux.tar.gz")
+        @test ps.quux[:] == ps.quux.segments[:]
+    end
+
+    function test_iteration(ps::PathSet)
+        @test eltype(ps.root) == String
+        @test tuple(ps.quux...) == ps.quux.segments
+        @test all(in(ps.quux), ("bar", "qux", "quux.tar.gz"))
     end
 
     function test_parents(ps::PathSet)
@@ -940,6 +904,8 @@ module TestPaths
         test_parse,
         test_convert,
         test_components,
+        test_indexing,
+        test_iteration,
         test_parents,
         test_descendants_and_ascendants,
         test_join,

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -25,6 +25,8 @@ include("testpkg.jl")
                 test_parse,
                 test_convert,
                 test_components,
+                test_indexing,
+                test_iteration,
                 test_parents,
                 test_descendants_and_ascendants,
                 test_join,

--- a/test/system.jl
+++ b/test/system.jl
@@ -8,6 +8,8 @@ ps = PathSet(; symlink=true)
         test_parse,
         test_convert,
         test_components,
+        test_indexing,
+        test_iteration,
         test_parents,
         test_descendants_and_ascendants,
         test_join,


### PR DESCRIPTION
Closes #70 

NOTE: I'm running with the assumption that indexing and iteration should just cover the segments and not include the `anchor` (e.g., `/`, `c:\\`, `s3://mybucket/`)?