### PR TITLE
Support absolute/relative and file/directory types

### DIFF
--- a/src/FilePathsBase.jl
+++ b/src/FilePathsBase.jl
@@ -14,6 +14,10 @@ export
     SystemPath,
     PosixPath,
     WindowsPath,
+    FilePath,
+    DirectoryPath,
+    RelativePath,
+    AbsolutePath,
     Mode,
     Status,
     FileBuffer,
@@ -68,15 +72,24 @@ export
 
 export isexecutable
 
-const PATH_TYPES = DataType[]
+const PATH_TYPES = Type[]
 
 function __init__()
     register(PosixPath)
     register(WindowsPath)
 end
 
+abstract type Form end
+struct Abs <: Form end
+struct Rel <: Form end
+
+abstract type Kind end
+struct Dir <: Kind end
+struct File <: Kind end
+# Could choose to extend this with Symlink?
+
 """
-    AbstractPath
+    AbstractPath{F<:Form, K<:Kind}
 
 Defines an abstract filesystem path.
 
@@ -98,7 +111,7 @@ Defines an abstract filesystem path.
 - `rm(path::T; kwags...)` - Remove a file or directory
 - `readdir(path::T)` - Scan all files and directories at a specific path level
 """
-abstract type AbstractPath end  # Define the AbstractPath here to avoid circular include dependencies
+abstract type AbstractPath{F<:Form, K<:Kind} end  # Define the AbstractPath here to avoid circular include dependencies
 
 """
     register(::Type{<:AbstractPath})
@@ -120,6 +133,12 @@ Return a boolean as to whether the string `x` fits the specified the path type.
 """
 function ispathtype end
 
+# define some aliases for parameterized abstract paths
+const AbsolutePath = AbstractPath{Abs}
+const RelativePath = AbstractPath{Rel}
+const FilePath = AbstractPath{<:Form, File}
+const DirectoryPath = AbstractPath{<:Form, Dir}
+
 include("constants.jl")
 include("utils.jl")
 include("libc.jl")
@@ -128,9 +147,9 @@ include("status.jl")
 include("buffer.jl")
 include("path.jl")
 include("aliases.jl")
+include("system.jl")
 include("posix.jl")
 include("windows.jl")
-include("system.jl")
 include("test.jl")
 include("deprecates.jl")
 

--- a/src/posix.jl
+++ b/src/posix.jl
@@ -4,28 +4,75 @@
 
 Represents any posix path (e.g., `/home/user/docs`)
 """
-struct PosixPath <: AbstractPath
+struct PosixPath{F<:Form, K<:Kind} <: SystemPath{F, K}
     segments::Tuple{Vararg{String}}
     root::String
 end
 
-PosixPath() = PosixPath(tuple(), "")
-PosixPath(segments::Tuple; root="") = PosixPath(segments, root)
+PosixPath() = PosixPath{Rel, Dir}(tuple(), "")
 
-function PosixPath(str::AbstractString)
-    str = string(str)
-    root = ""
+# WARNING: We don't know if this was a directory of file at this point
+PosixPath(segments::Tuple; root="") = PosixPath{Rel, Kind}(segments, root)
 
-    isempty(str) && return PosixPath(tuple("."))
+PosixPath(str::AbstractString) = parse(PosixPath, str)
 
-    tokenized = split(str, POSIX_PATH_SEPARATOR)
-    if isempty(tokenized[1])
-        root = POSIX_PATH_SEPARATOR
-    end
-    return PosixPath(tuple(map(String, filter!(!isempty, tokenized))...), root)
+# High level tryparse for the entire type
+function Base.tryparse(::Type{PosixPath}, str::AbstractString)
+    # Only bother with `tryparse` if we're on a posix system.
+    # NOTE: You can always bypass this behaviour by calling the lower level methods.
+    Sys.isunix() || return nothing
+    F = isabspath(str) ? Abs : Rel
+    K = isdirpath(str) ? Dir : File
+    return tryparse(PosixPath{F, K}, str)
 end
 
-ispathtype(::Type{PosixPath}, str::AbstractString) = Sys.isunix()
+# Internal tryparse methods for different expected permutations
+function Base.tryparse(::Type{PosixPath{Rel, File}}, str::AbstractString)
+    str = normpath(str)
+    isempty(str) && return nothing
+
+    tokenized = split(str, POSIX_PATH_SEPARATOR)
+
+    # `str` starts or ends with separator then we don't have a valid relative file.
+    isempty(first(tokenized)) || isempty(last(tokenized)) && return nothing
+
+    return PosixPath{Rel, File}(tuple(String.(tokenized)...), "")
+end
+
+function Base.tryparse(::Type{PosixPath{Rel, Dir}}, str::AbstractString)
+    str = normpath(str)
+    isempty(str) && return PosixPath{Rel, Dir}(tuple("."), "")
+
+    tokenized = split(str, POSIX_PATH_SEPARATOR)
+    # `str` does not start but ends with separator or we don't have a valid relative directory.
+    !isempty(first(tokenized)) && isempty(last(tokenized)) || return nothing
+
+    return PosixPath{Rel, Dir}(tuple(String.(tokenized[1:end-1])...), "")
+end
+
+function Base.tryparse(::Type{PosixPath{Abs, File}}, str::AbstractString)
+    str = normpath(str)
+    isempty(str) && return nothing
+
+    tokenized = split(str, POSIX_PATH_SEPARATOR)
+
+    # `str` starts but doesn't end with separator or we don't have a valid absolute file.
+    isempty(first(tokenized)) && !isempty(last(tokenized)) || return nothing
+
+    return PosixPath{Abs, File}(tuple(String.(tokenized[2:end])...), POSIX_PATH_SEPARATOR)
+end
+
+function Base.tryparse(::Type{PosixPath{Abs, Dir}}, str::AbstractString)
+    str = normpath(str)
+    isempty(str) && return nothing
+
+    tokenized = split(str, POSIX_PATH_SEPARATOR)
+
+    # `str` starts and ends with separator or we don't have a valid absolute file.
+    isempty(first(tokenized)) && isempty(last(tokenized)) || return nothing
+
+    return PosixPath{Abs, Dir}(tuple(String.(tokenized[2:end-1])...), POSIX_PATH_SEPARATOR)
+end
 
 function Base.expanduser(fp::PosixPath)::PosixPath
     p = fp.segments

--- a/src/system.jl
+++ b/src/system.jl
@@ -1,49 +1,10 @@
 """
-    SystemPath
+    SystemPath{F<:Form, K<:Kind} <: AbstractPath{F, K}
 
 A union of `PosixPath` and `WindowsPath` which is used for writing
 methods that wrap base functionality.
 """
-const SystemPath = Union{PosixPath, WindowsPath}
-
-Path() = @static Sys.isunix() ? PosixPath() : WindowsPath()
-Path(pieces::Tuple{Vararg{String}}) =
-    @static Sys.isunix() ? PosixPath(pieces) : WindowsPath(pieces)
-
-"""
-    @__PATH__ -> SystemPath
-
-@__PATH__ expands to a path with the directory part of the absolute path
-of the file containing the macro. Returns an empty Path if run from a REPL or
-if evaluated by julia -e <expr>.
-"""
-macro __PATH__()
-    p = Path(dirname(string(__source__.file)))
-    return p === nothing ? :(Path()) : :($p)
-end
-
-"""
-    @__FILEPATH__ -> SystemPath
-
-@__FILEPATH__ expands to a path with the absolute file path of the file
-containing the macro. Returns an empty Path if run from a REPL or if
-evaluated by julia -e <expr>.
-"""
-macro __FILEPATH__()
-    p = Path(string(__source__.file))
-    return p === nothing ? :(Path()) : :($p)
-end
-
-"""
-    @LOCAL(filespec)
-
-Construct an absolute path to `filespec` relative to the source file
-containing the macro call.
-"""
-macro LOCAL(filespec)
-    p = join(Path(dirname(string(__source__.file))), Path(filespec))
-    return :($p)
-end
+abstract type SystemPath{F<:Form, K<:Kind} <: AbstractPath{F, K} end
 
 exists(fp::SystemPath) = ispath(string(fp))
 

--- a/src/windows.jl
+++ b/src/windows.jl
@@ -4,17 +4,21 @@
 
 Represents a windows path (e.g., `C:\\User\\Documents`)
 """
-struct WindowsPath <: AbstractPath
+struct WindowsPath{F<:Form, K<:Kind} <: SystemPath{F, K}
     segments::Tuple{Vararg{String}}
     root::String
     drive::String
     separator::String
+end
 
-    function WindowsPath(
-        segments::Tuple, root::String, drive::String, separator::String=WIN_PATH_SEPARATOR
+# WARNING: We don't know if this was a directory of file at this point
+function WindowsPath(
+    segments::Tuple, root::String, drive::String, separator::String=WIN_PATH_SEPARATOR
+)
+    F = isempty(root) ? Rel : Abs
+    return WindowsPath{F, Kind}(
+        Tuple(Iterators.filter(!isempty, segments)), root, drive, separator
     )
-        return new(Tuple(Iterators.filter(!isempty, segments)), root, drive, separator)
-    end
 end
 
 function _win_splitdrive(fp::String)
@@ -28,42 +32,80 @@ function WindowsPath(segments::Tuple; root="", drive="", separator="\\")
     return WindowsPath(segments, root, drive, separator)
 end
 
-function WindowsPath(str::AbstractString)
-    isempty(str) && WindowsPath(tuple("."), "", "")
+WindowsPath(str::AbstractString) = parse(WindowsPath, str)
 
-    if startswith(str, "\\\\?\\")
-        error("The \\\\?\\ prefix is currently not supported.")
-    end
+# High level tryparse for the entire type
+function Base.tryparse(::Type{WindowsPath}, str::AbstractString)
+    # Only bother with `tryparse` if we're on a windows system.
+    # NOTE: You can always bypass this behaviour by calling the lower level methods.
+    Sys.iswindows() || return nothing
+    startswith(str, "\\\\?\\") && return nothing
+    startswith(str, "\\\\") && return nothing
 
-    str = replace(str, POSIX_PATH_SEPARATOR => WIN_PATH_SEPARATOR)
+    F = isabspath(str) ? Abs : Rel
+    K = isdirpath(str) ? Dir : File
+    return tryparse(WindowsPath{F, K}, str)
+end
 
-    if startswith(str, "\\\\")
-        error("UNC paths are currently not supported.")
-    elseif startswith(str, "\\")
-        tokenized = split(str, WIN_PATH_SEPARATOR)
+# Internal tryparse methods for different expected permutations
+function Base.tryparse(::Type{WindowsPath{Rel, File}}, str::AbstractString, raise::Bool)
+    str = normpath(str)
+    isempty(str) && return nothing
 
-        return WindowsPath(tuple(String.(tokenized[2:end])...), WIN_PATH_SEPARATOR, "")
-    elseif occursin(":", str)
-        l_drive, l_path = _win_splitdrive(str)
+    drive, path = _win_splitdrive(str)
+    tokenized = split(path, WIN_PATH_SEPARATOR)
 
-        tokenized = split(l_path, WIN_PATH_SEPARATOR)
+    # path starts or ends with separator then we don't have a valid relative file.
+    isempty(first(tokenized)) || isempty(last(tokenized)) && return nothing
 
-        l_root = isempty(tokenized[1]) ? WIN_PATH_SEPARATOR : ""
+    return WindowsPath{Rel, File}(tuple(String.(tokenized)...), "", drive)
+end
 
-        if isempty(tokenized[1])
-            tokenized = tokenized[2:end]
-        end
+function Base.tryparse(::Type{WindowsPath{Rel, Dir}}, str::AbstractString)
+    str = normpath(str)
+    isempty(str) && return WindowsPath{Rel, Dir}(tuple("."), "", "")
 
-        if !isempty(l_drive) || !isempty(l_root)
-            tokenized = tuple(tokenized...)
-        end
+    drive, path = _win_splitdrive(str)
+    tokenized = split(path, WIN_PATH_SEPARATOR)
 
-        return WindowsPath(tuple(String.(tokenized)...), l_root, l_drive)
-    else
-        tokenized = split(str, WIN_PATH_SEPARATOR)
+    # `str` does not start but ends with separator or we don't have a valid relative directory.
+    !isempty(first(tokenized)) && isempty(last(tokenized)) || return nothing
 
-        return WindowsPath(tuple(String.(tokenized)...), "", "")
-    end
+    return WindowsPath{Rel, Dir}(tuple(String.(tokenized[1:end-1])...), "", drive)
+end
+
+function Base.tryparse(::Type{WindowsPath{Abs, File}}, str::AbstractString)
+    str = normpath(str)
+    isempty(str) && return nothing
+
+    drive, path = _win_splitdrive(str)
+    tokenized = split(path, WIN_PATH_SEPARATOR)
+
+    # `str` starts but doesn't end with separator or we don't have a valid absolute file.
+    isempty(first(tokenized)) && !isempty(last(tokenized)) || return nothing
+
+    return WindowsPath{Abs, File}(
+        tuple(String.(tokenized[2:end])...),
+        WIN_PATH_SEPARATOR,
+        drive,
+    )
+end
+
+function Base.tryparse(::Type{WindowsPath{Abs, Dir}}, str::AbstractString)
+    str = normpath(str)
+    isempty(str) && return nothing
+
+    drive, path = _win_splitdrive(str)
+    tokenized = split(path, WIN_PATH_SEPARATOR)
+
+    # `str` starts and ends with separator or we don't have a valid absolute file.
+    isempty(first(tokenized)) && isempty(last(tokenized)) || return nothing
+
+    return WindowsPath{Abs, Dir}(
+        tuple(String.(tokenized[2:end-1])...),
+        WIN_PATH_SEPARATOR,
+        drive
+    )
 end
 
 function Base.:(==)(a::WindowsPath, b::WindowsPath)


### PR DESCRIPTION
# Summary

- [X] Introduce `Form` and `Kind` concepts (though not exported) which paths are parameterized by.
- [X] Aliases for dispatching (e.g., `AbsolutePath`, `RelativePath`, `FilePath`, `DirectoryPath`) 
- [X] Stricter parsing based on the above types (e.g., directories must end with a separator)
- [X] Dropping `ispathtype` in favour of just `tryparse`.
- [ ] Wrapper methods to return the appropriate types
- [ ] Extra tests for the new parsing approach
- [ ] Update AWSS3.jl
- [ ] Add support to FTPClient.jl?

Closes #72, #78 and #79 