### PR TITLE
Add some C_NULL checks for our libc calls

### DIFF
--- a/src/libc.jl
+++ b/src/libc.jl
@@ -73,6 +73,7 @@ function User(name::String)
         Cpasswd()
     end
 
+    systemerror(:getpwnam, ps == C_NULL)
     User(ps)
 end
 
@@ -83,6 +84,7 @@ function User(uid::UInt)
         Cpasswd()
     end
 
+    systemerror(:getpwuid, ps == C_NULL)
     User(ps)
 end
 
@@ -110,6 +112,7 @@ function Group(name::String)
         Cgroup()
     end
 
+    systemerror(:getgrnam, ps == C_NULL)
     Group(ps)
 end
 
@@ -120,6 +123,7 @@ function Group(gid::UInt)
         Cgroup()
     end
 
+    systemerror(:getgrgid, gr == C_NULL)
     Group(gr)
 end
 


### PR DESCRIPTION
Closes https://github.com/rofinn/FilePaths.jl/issues/49

**Previous**

```julia
julia> using FilePathsBase
[ Info: Precompiling FilePathsBase [48062228-2e41-5def-b9a4-89aafe57970f]

julia> FilePathsBase.User(UInt64(12345))

signal (11): Segmentation fault: 11
in expression starting at REPL[2]:1
unsafe_load at ./pointer.jl:105 [inlined]
unsafe_load at ./pointer.jl:105 [inlined]
User at /Users/rory/repos/FilePathsBase.jl/src/libc.jl:63 [inlined]
User at /Users/rory/repos/FilePathsBase.jl/src/libc.jl:86
unknown function (ip: 0x115a618f2)
jl_apply at /Users/julia/buildbot/worker/package_macos64/build/src/./julia.h:1692 [inlined]
do_call at /Users/julia/buildbot/worker/package_macos64/build/src/interpreter.c:369
eval_body at /Users/julia/buildbot/worker/package_macos64/build/src/interpreter.c:0
jl_interpret_toplevel_thunk at /Users/julia/buildbot/worker/package_macos64/build/src/interpreter.c:911
jl_toplevel_eval_flex at /Users/julia/buildbot/worker/package_macos64/build/src/toplevel.c:814
jl_toplevel_eval_flex at /Users/julia/buildbot/worker/package_macos64/build/src/toplevel.c:764
jl_toplevel_eval at /Users/julia/buildbot/worker/package_macos64/build/src/toplevel.c:823 [inlined]
jl_toplevel_eval_in at /Users/julia/buildbot/worker/package_macos64/build/src/toplevel.c:843
eval at ./boot.jl:331
eval_user_input at /Users/julia/buildbot/worker/package_macos64/build/usr/share/julia/stdlib/v1.4/REPL/src/REPL.jl:86
macro expansion at /Users/julia/buildbot/worker/package_macos64/build/usr/share/julia/stdlib/v1.4/REPL/src/REPL.jl:118 [inlined]
#26 at ./task.jl:358
jl_apply at /Users/julia/buildbot/worker/package_macos64/build/src/./julia.h:1692 [inlined]
start_task at /Users/julia/buildbot/worker/package_macos64/build/src/task.c:687
Allocations: 1806103 (Pool: 1805627; Big: 476); GC: 2
fish: 'julia --project=.' terminated by signal SIGSEGV (Address boundary error)
```

**New**
```julia
julia> using FilePathsBase
[ Info: Precompiling FilePathsBase [48062228-2e41-5def-b9a4-89aafe57970f]

julia> FilePathsBase.User(UInt64(12345))
ERROR: SystemError: getpwuid: Undefined error: 0
Stacktrace:
 [1] systemerror(::Symbol, ::Int32; extrainfo::Nothing) at ./error.jl:168
 [2] #systemerror#50 at ./error.jl:167 [inlined]
 [3] systemerror at ./error.jl:167 [inlined]
 [4] FilePathsBase.User(::UInt64) at /Users/rory/repos/FilePathsBase.jl/src/libc.jl:87
 [5] top-level scope at REPL[2]:1
```