### PR TITLE
Add mmap support for SystemPath

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,10 +1,11 @@
 name = "FilePathsBase"
 uuid = "48062228-2e41-5def-b9a4-89aafe57970f"
 authors = ["Rory Finnegan"]
-version = "0.9.3"
+version = "0.9.4"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
+Mmap = "a63ad114-7e13-5084-954f-fe012c677804"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"

--- a/src/FilePathsBase.jl
+++ b/src/FilePathsBase.jl
@@ -3,6 +3,7 @@ __precompile__()
 module FilePathsBase
 
 using Dates
+using Mmap
 using Printf
 using UUIDs
 

--- a/src/system.jl
+++ b/src/system.jl
@@ -392,3 +392,5 @@ end
 function canonicalize(fp::T) where T<:SystemPath
     return parse(T, realpath(string(fp)))
 end
+
+Mmap.mmap(fp::SystemPath, args...; kwargs...) = Mmap.mmap(string(fp), args...; kwargs...)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,6 +3,7 @@ using FilePathsBase: /, join
 using Base.Filesystem
 using Dates: datetime2unix
 using JLSO
+using Mmap
 using Test
 
 using FilePathsBase.TestPaths

--- a/test/system.jl
+++ b/test/system.jl
@@ -465,7 +465,10 @@ ps = PathSet(; symlink=true)
                 end
 
                 @testset "Mmap.mmap" begin
-                    @test Mmap.mmap(p"README.md") == Mmap.mmap("README.md")
+                    fpmap, strmap = Mmap.mmap(p"README.md"), Mmap.mmap("README.md")
+                    @test fpmap == strmap
+                    # Ensure that the mmap objects get finalized before we cleanup our working directory.
+                    finalize.([fpmap, strmap])
                 end
             end
         end

--- a/test/system.jl
+++ b/test/system.jl
@@ -463,6 +463,10 @@ ps = PathSet(; symlink=true)
                     content = read(joinpath(docsdir, "src", "api.md"), String)
                     @test write(p"writefp", content) == write("writestr", content)
                 end
+
+                @testset "Mmap.mmap" begin
+                    @test Mmap.mmap(p"README.md") == Mmap.mmap("README.md")
+                end
             end
         end
     end


### PR DESCRIPTION
For reference, this is because CSV.jl is moving towards using mmap by default. It should still fallback if mmap fails (e.g., remote filepaths where reading everything into memory will still work).