### PR TITLE
Make walkpath return a typed collection

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "FilePathsBase"
 uuid = "48062228-2e41-5def-b9a4-89aafe57970f"
 authors = ["Rory Finnegan"]
-version = "0.9.5"
+version = "0.9.6"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/path.jl
+++ b/src/path.jl
@@ -706,8 +706,8 @@ end
 
 Performs a depth first search through the directory structure
 """
-function walkpath(fp::AbstractPath; topdown=true, follow_symlinks=false, onerror=throw)
-    return Channel() do chnl
+function walkpath(fp::P; topdown=true, follow_symlinks=false, onerror=throw)  where P <: AbstractPath
+    return Channel(ctype=P) do chnl
         for p in readpath(fp)
             topdown && put!(chnl, p)
             if isdir(p) && (follow_symlinks || !islink(p))

--- a/src/test.jl
+++ b/src/test.jl
@@ -561,13 +561,15 @@ module TestPaths
         end
     end
 
-    function test_walkpath(ps::PathSet)
+    function test_walkpath(ps::PathSet{P}) where P
         @testset "walkpath" begin
             topdown = [ps.bar, ps.qux, ps.quux, ps.foo, ps.baz, ps.fred, ps.plugh]
             bottomup = [ps.quux, ps.qux, ps.bar, ps.baz, ps.foo, ps.plugh, ps.fred]
 
             @test collect(walkpath(ps.root; topdown=true)) == topdown
             @test collect(walkpath(ps.root; topdown=false)) == bottomup
+
+            @test eltype(walkpath(ps.root)) == P  # should return a typed collection
         end
     end
 


### PR DESCRIPTION
So that `collect(walkpath(...))` doesn't return a `Vector{Any}`

It does assume that `readpath(::P)::P` but i think that is a safe enough assumption.
If a new filepath wants to break that later we can deal with that later? 