### PR TITLE
fix inappropriately restrictive typing of PATH_TYPES

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "FilePathsBase"
 uuid = "48062228-2e41-5def-b9a4-89aafe57970f"
 authors = ["Rory Finnegan"]
-version = "0.9.7"
+version = "0.9.8"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/FilePathsBase.jl
+++ b/src/FilePathsBase.jl
@@ -1,5 +1,3 @@
-__precompile__()
-
 module FilePathsBase
 
 using Dates
@@ -69,7 +67,7 @@ export
 
 export isexecutable
 
-const PATH_TYPES = DataType[]
+const PATH_TYPES = Type[]
 
 function __init__()
     # Register the default fallback path type based on the os.


### PR DESCRIPTION
This changes the `eltype` of the `PATH_TYPES` constant from `DataType` to `Type`.  The reason for this is that `DataType` prevents abstract types from being used, which is perhaps a problem for `abstract type`, but becomes a problem because parametric types cannot be used either.  In other words, this PR enables the use of parametric types as path types.