### PR TITLE
Relaxing UInt types in Group

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "FilePathsBase"
 uuid = "48062228-2e41-5def-b9a4-89aafe57970f"
 authors = ["Rory Finnegan"]
-version = "0.9.8"
+version = "0.9.9"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/libc.jl
+++ b/src/libc.jl
@@ -123,7 +123,7 @@ Base.show(io::IO, group::Group) = print(io, "$(group.gid) ($(group.name))")
         return Group(gr)
     end
 
-    Group() = Group(UInt64(ccall(:getegid, Cint, ())))
+    Group() = Group(UInt(ccall(:getegid, Cint, ())))
 else
     Group(name::String) = Group(Cgroup())
     Group(uid::UInt) = Group(Cgroup())

--- a/src/libc.jl
+++ b/src/libc.jl
@@ -123,7 +123,7 @@ Base.show(io::IO, group::Group) = print(io, "$(group.gid) ($(group.name))")
         return Group(gr)
     end
 
-    Group() = Group(UInt(ccall(:getegid, Cint, ())))
+    Group() = Group(UInt64(ccall(:getegid, Cint, ())))
 else
     Group(name::String) = Group(Cgroup())
     Group(uid::UInt) = Group(Cgroup())

--- a/test/system.jl
+++ b/test/system.jl
@@ -285,14 +285,10 @@ ps = PathSet(; symlink=true)
                 my_group = FilePathsBase.Group()
             
                 u_int = FilePathsBase.User(UInt(my_user.uid))
-                u_int64 = FilePathsBase.User(UInt64(my_user.uid))
                 g_int = FilePathsBase.Group(UInt(my_group.gid))
-                g_int64 = FilePathsBase.Group(UInt64(my_group.gid))
             
                 @test u_int.uid isa UInt
-                @test u_int64.uid isa UInt64
                 @test g_int.gid isa UInt
-                @test g_int64.gid isa UInt64
             end
         end
 

--- a/test/system.jl
+++ b/test/system.jl
@@ -287,8 +287,10 @@ ps = PathSet(; symlink=true)
                 u_int = FilePathsBase.User(UInt(my_user.uid))
                 g_int = FilePathsBase.Group(UInt(my_group.gid))
             
-                @test u_int.uid isa UInt
-                @test g_int.gid isa UInt
+                @test u_int isa FilePathsBase.User
+                @test g_int isa FilePathsBase.Group
+                @test u_int.uid isa Unsigned
+                @test g_int.gid isa Unsigned
             end
         end
 

--- a/test/system.jl
+++ b/test/system.jl
@@ -279,6 +279,21 @@ ps = PathSet(; symlink=true)
                 compare_stats(stat(fp), stat(string(fp)))
                 compare_stats(lstat(fp), lstat(string(fp)))
             end
+
+            @testset "User/Group constructors" begin
+                my_user = FilePathsBase.User()
+                my_group = FilePathsBase.Group()
+            
+                u_int = FilePathsBase.User(UInt(my_user.uid))
+                u_int64 = FilePathsBase.User(UInt64(my_user.uid))
+                g_int = FilePathsBase.Group(UInt(my_group.gid))
+                g_int64 = FilePathsBase.Group(UInt64(my_group.gid))
+            
+                @test u_int.uid isa UInt
+                @test u_int64.uid isa UInt64
+                @test g_int.gid isa UInt
+                @test g_int64.gid isa UInt64
+            end
         end
 
         # We aren't going to do all the `isfifo`, `ischardev`, etc.


### PR DESCRIPTION
Trying to fix the following error:

```MethodError: no method matching FilePathsBase.Group(::UInt64)```

by relaxing UInt types in Group similarly to [here](https://github.com/rofinn/FilePathsBase.jl/commit/8cc644314fdd6db9fac8e0a3e169d3a4523bc4d6).  

Initial commit is attempting to recreate the error as it occurs only on 32-bit machines.