### PR TITLE
Update walkdir / walkpath in API table

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -56,7 +56,7 @@ mv | mv
 download | download
 readdir | readdir
 N/A | readpath
-walkpath | walkpath
+walkdir | walkpath
 rm | rm
 touch | touch
 tempname() | tempname(::Type{<:AbstractPath}) (or tmpname)


### PR DESCRIPTION
`walkpath` does not exist in `Base`, and `walkdir` has a different behavior, so I wasn't sure if I should make this two rows or treat them as equivalent.

```
julia> p = "docs"
"docs"

julia> for item in walkdir(p)
           @show item
       end
item = ("docs", ["src"], ["Project.toml", "make.jl"])
item = ("docs/src", String[], ["index.md"])

julia> for item in walkpath(p)
           @show item
       end
ERROR: UndefVarError: walkpath not defined
Stacktrace:
 [1] top-level scope
   @ ./REPL[3]:1

julia> using FilePaths

julia> for item in walkpath(p)
           @show item
       end
ERROR: MethodError: no method matching walkpath(::String)
Closest candidates are:
  walkpath(::P; topdown, follow_symlinks, onerror) where P<:AbstractPath at /home/kevin/.julia/packages/FilePathsBase/YFK4h/src/pat
h.jl:709
Stacktrace:
 [1] top-level scope
   @ ./REPL[5]:1

julia> for item in walkpath(Path(p))
           @show item
       end
item = p"docs/Project.toml"
item = p"docs/make.jl"
item = p"docs/src"
item = p"docs/src/index.md"
```