### PR TITLE
implemented diskusage

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -165,6 +165,7 @@ Base.mv(::AbstractPath, ::AbstractPath)
 Base.download(::AbstractString, ::AbstractPath)
 FilePathsBase.readpath
 FilePathsBase.walkpath
+FilePathsBase.diskusage
 Base.open(::AbstractPath)
 FilePathsBase.tmpname
 FilePathsBase.tmpdir

--- a/src/FilePathsBase.jl
+++ b/src/FilePathsBase.jl
@@ -53,6 +53,7 @@ export
     raw,
     readpath,
     walkpath,
+    diskusage,
 
     # Macros
     @p_str,

--- a/src/path.jl
+++ b/src/path.jl
@@ -839,5 +839,5 @@ node block sizes.
 This is the preferred method for computing file or directory sizes for remote file
 systems as it should limit the number of remote calls where possible.
 """
-diskusage(fp::AbstractPath) = diskusage(walkpath(fp))
-diskusage(itr) = sum(filesize.(walkpath(fp)))
+diskusage(fp::AbstractPath) = isfile(fp) ? filesize(fp) : diskusage(walkpath(fp))
+diskusage(itr) = sum(map(filesize, itr))

--- a/src/path.jl
+++ b/src/path.jl
@@ -840,4 +840,4 @@ This is the preferred method for computing file or directory sizes for remote fi
 systems as it should limit the number of remote calls where possible.
 """
 diskusage(fp::AbstractPath) = isfile(fp) ? filesize(fp) : diskusage(walkpath(fp))
-diskusage(itr) = sum(map(filesize, itr))
+diskusage(itr) = mapreduce(filesize, +, itr)

--- a/src/path.jl
+++ b/src/path.jl
@@ -828,3 +828,16 @@ isdescendant(fp::P, asc::P) where {P <: AbstractPath} = fp == asc || asc in pare
 Returns `true` if `fp` is a directory containing `desc`.
 """
 isascendant(fp::P, desc::P) where {P <: AbstractPath} = isdescendant(desc, fp)
+
+"""
+    diskusage(fp::AbstractPath)
+
+Returns the total size in bytes of the `AbstractPath`.  This is guaranteed to give the same
+result as summing the `filesize` of all nodes in `walkpath(fp)` including directory
+node block sizes.
+
+This is the preferred method for computing file or directory sizes for remote file
+systems as it should limit the number of remote calls where possible.
+"""
+diskusage(fp::AbstractPath) = diskusage(walkpath(fp))
+diskusage(itr) = sum(filesize.(walkpath(fp)))

--- a/src/test.jl
+++ b/src/test.jl
@@ -574,7 +574,8 @@ module TestPaths
             @test eltype(walkpath(ps.root)) == P  # should return a typed collection
 
             # tests consistency of definition, assume network usage acceptable
-            @test diskusage(ps.root) == sum(filesize.(walkpath(ps.root)))
+            @test diskusage(ps.root) == mapreduce(filesize, +, walkpath(ps.root))
+            @test diskusage(ps.baz) == ncodeunits("Hello World!")
         end
     end
 

--- a/src/test.jl
+++ b/src/test.jl
@@ -572,6 +572,9 @@ module TestPaths
             @test collect(walkpath(ps.root; topdown=false)) == bottomup
 
             @test eltype(walkpath(ps.root)) == P  # should return a typed collection
+
+            # tests consistency of definition, assume network usage acceptable
+            @test diskusage(ps.root) == sum(filesize.(walkpath(ps.root)))
         end
     end
 


### PR DESCRIPTION
This implements what's discussed in #136 .

I have added a test for the interface that simply ensures that it is consistent with the definition provided here.  Interestingly, I have found that it is surprisingly tricky to come up with consistent tests as the apparent size of directory nodes can vary even on the same system (at least on `ext4`).