### PR TITLE
add `propertynames`

### DIFF
--- a/src/path.jl
+++ b/src/path.jl
@@ -49,6 +49,11 @@ function Base.getproperty(fp::T, attr::Symbol) where T <: AbstractPath
     end
 end
 
+function Base.propertynames(::T, private::Bool=false) where T <: AbstractPath
+    public_names = (:drive, :root, :anchor, :separator)
+    return private ? Base.merge_names(public_names, fieldnames(T)) : public_names
+end
+
 #=
 We only want to print the macro string syntax when compact is true and
 we want print to just return the string (this allows `string` to work normally)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -19,6 +19,11 @@ include("testpkg.jl")
         # Test that our weird registered path works
         ps = PathSet(TestPkg.posix2test(tmpdir()) / "pathset_root"; symlink=true)
 
+        @testset "`propertynames`" begin
+            @test propertynames(ps.root) == (:drive, :root, :anchor, :separator)
+            @test propertynames(ps.root, true) == (:drive, :root, :anchor, :separator, :segments)
+        end
+        
         @testset "$(typeof(ps.root))" begin
             testsets = [
                 test_registration,


### PR DESCRIPTION
Closes #131

Here, I define the "public" properties as the `getproperty` overloads, and the private properties as any remaining internal fields. My thinking is then downstream types can accept this or define their own `propertynames` to declare which fields whey want to be private or not.

I used `Base.merge_names` here; this is a Julia internal function so perhaps we should not depend on it. It has at least existed for 4 years (https://github.com/JuliaLang/julia/blame/ff001a4e1f5b7f949f5a2328520a7e78bc1957b4/base/namedtuple.jl#L211). The reason I wanted to use it is to have a fast way of merging the tuples of symbols without duplicates (a slow alternative would be `Tuple(unique((public_names..., fieldnames(T)...)))`).