### PR TITLE
Add work around for temp file/directory collisions

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -7,6 +7,7 @@ version = "0.9.14"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 Mmap = "a63ad114-7e13-5084-954f-fe012c677804"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 

--- a/src/FilePathsBase.jl
+++ b/src/FilePathsBase.jl
@@ -3,6 +3,7 @@ module FilePathsBase
 using Dates
 using Mmap
 using Printf
+using Random
 using UUIDs
 
 import Base: ==
@@ -69,6 +70,7 @@ export
 export isexecutable
 
 const PATH_TYPES = Type[]
+const RNG = MersenneTwister(314159)
 
 function __init__()
     # Register the default fallback path type based on the os.

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,11 +4,35 @@ using Base.Filesystem
 using Dates: datetime2unix
 using JLSO
 using Mmap
+using Random
 using Test
 
 using FilePathsBase.TestPaths
 
 include("testpkg.jl")
+
+function test_mktmp_collisions(ps::PathSet)
+    # https://github.com/rofinn/FilePathsBase.jl/issues/142
+    @testset "mktemp collisions" begin
+        temp_root = ps.root / "tmp"
+        try
+            mkdir(temp_root)
+            # Create a set of of temp files that we don't cleanup
+            # set the RNG so that they intentionally collide and trigger
+            # our error conditions
+            Random.seed!(FilePathsBase.RNG, 0)
+            for i = 1:4
+                fp, io = mktemp(temp_root)
+                close(io)
+            end
+
+            Random.seed!(FilePathsBase.RNG, 0)
+            @test_throws ErrorException mktemp(temp_root)
+        finally
+            rm(temp_root, recursive=true)
+        end
+    end
+end
 
 @testset "FilePathsBase" begin
     include("mode.jl")
@@ -23,7 +47,7 @@ include("testpkg.jl")
             @test propertynames(ps.root) == (:drive, :root, :anchor, :separator)
             @test propertynames(ps.root, true) == (:drive, :root, :anchor, :separator, :segments)
         end
-        
+
         @testset "$(typeof(ps.root))" begin
             testsets = [
                 test_registration,
@@ -66,6 +90,7 @@ include("testpkg.jl")
                 test_tmpname,
                 test_tmpdir,
                 test_mktmp,
+                test_mktmp_collisions,
                 test_mktmpdir,
                 test_download,
                 test_issocket,


### PR DESCRIPTION
I'm not sure if this is still necessary on 1.6, but it resolves #142 for non-system paths if it's still an issue.