### PR TITLE
Revise overloaded temp methods

### DIFF
--- a/src/path.jl
+++ b/src/path.jl
@@ -687,8 +687,8 @@ Download a file from the remote `url` and save it to the `localfile` path.
 NOTE: Not downloading into a `localfile` directory matches the base Julia behaviour.
 https://github.com/rofinn/FilePathsBase.jl/issues/48
 """
-function Base.download(url::AbstractString, localfile::P) where P <: AbstractPath
-    mktemp(P) do fp, io
+function Base.download(url::AbstractString, localfile::AbstractPath)
+    mktmp() do fp, io
         download(url, fp)
         cp(fp, localfile; force=false)
     end
@@ -767,26 +767,22 @@ Base.write(fp::AbstractPath, x) = open(io -> write(io, x), fp, "w")
 # Default `touch` will just write an empty string to a file
 Base.touch(fp::AbstractPath) = write(fp, "")
 
-Base.tempname(::Type{<:AbstractPath}) = Path(tempname())
-tmpname() = tempname(SystemPath)
+Base.tempname(P::Type{<:AbstractPath}; kwargs...) = tempname(tempdir(P); kwargs...)
+Base.mktemp(P::Type{<:AbstractPath}; kwargs...) = mktemp(tempdir(P); kwargs...)
+Base.mktemp(fn::Function, P::Type{<:AbstractPath}; kwargs...) = mktemp(fn, tempdir(P); kwargs...)
+Base.mktempdir(P::Type{<:AbstractPath}; kwargs...) = mktempdir(tempdir(P); kwargs...)
+Base.mktempdir(fn::Function, P::Type{<:AbstractPath}; kwargs...) = mktempdir(fn, tempdir(P); kwargs...)
 
-Base.tempdir(::Type{<:AbstractPath}) = Path(tempdir())
-tmpdir() = tempdir(SystemPath)
+function Base.tempname(parent::AbstractPath; prefix="jl_", cleanup=true)
+    isdir(parent) || throw(ArgumentError("$(repr(parent)) is not a directory"))
+    fp = parent / string(prefix, uuid1())
+    @assert !exists(fp)
+    cleanup && temp_cleanup(fp)
+    return fp
+end
 
-Base.mktemp(P::Type{<:AbstractPath}) = mktemp(tempdir(P))
-mktmp() = mktemp(SystemPath)
-
-Base.mktemp(fn::Function, P::Type{<:AbstractPath}) = mktemp(fn, tempdir(P))
-mktmp(fn::Function) = mktemp(fn, SystemPath)
-
-Base.mktempdir(P::Type{<:AbstractPath}) = mktempdir(tempdir(P))
-mktmpdir() = mktempdir(SystemPath)
-
-Base.mktempdir(fn::Function, P::Type{<:AbstractPath}) = mktempdir(fn, tempdir(P))
-mktmpdir(fn::Function) = mktempdir(fn, SystemPath)
-
-function Base.mktemp(parent::AbstractPath)
-    fp = parent / string(uuid4())
+function Base.mktemp(parent::AbstractPath; kwargs...)
+    fp = tempname(parent; kwargs...)
     # touch the file in case `open` isn't implement for the path and
     # we're buffering locally.
     touch(fp)
@@ -794,14 +790,14 @@ function Base.mktemp(parent::AbstractPath)
     return fp, io
 end
 
-function Base.mktempdir(parent::AbstractPath)
-    fp = parent / string(uuid4())
+function Base.mktempdir(parent::AbstractPath; kwargs...)
+    fp = tempname(parent; kwargs...)
     mkdir(fp)
     return fp
 end
 
-function Base.mktemp(fn::Function, parent::AbstractPath)
-    (tmp_fp, tmp_io) = mktmp(parent)
+function Base.mktemp(fn::Function, parent::AbstractPath; kwargs...)
+    (tmp_fp, tmp_io) = mktemp(parent; kwargs...)
     try
         fn(tmp_fp, tmp_io)
     finally
@@ -810,8 +806,8 @@ function Base.mktemp(fn::Function, parent::AbstractPath)
     end
 end
 
-function Base.mktempdir(fn::Function, parent::AbstractPath)
-    tmpdir = mktmpdir(parent)
+function Base.mktempdir(fn::Function, parent::AbstractPath; kwargs...)
+    tmpdir = mktmpdir(parent; kwargs...)
     try
         fn(tmpdir)
     finally
@@ -819,8 +815,15 @@ function Base.mktempdir(fn::Function, parent::AbstractPath)
     end
 end
 
-mktmp(arg1, args...) = mktemp(arg1, args...)
-mktmpdir(arg1, args...) = mktempdir(arg1, args...)
+mktmp(arg1, args...; kwargs...) = mktemp(arg1, args...; kwargs...)
+mktmpdir(arg1, args...; kwargs...) = mktempdir(arg1, args...; kwargs...)
+
+function temp_cleanup(fp::AbstractPath)
+    atexit() do
+        # Might not work in all cases, but default to recursively deleting the path on exit
+        rm(fp; force=true, recursive=true)
+    end
+end
 
 """
 	isdescendant(fp::P, asc::P) where {P <: AbstractPath} -> Bool

--- a/src/system.jl
+++ b/src/system.jl
@@ -236,6 +236,12 @@ Base.touch(fp::T) where {T<:SystemPath} = parse(T, touch(string(fp)))
 
 Base.tempdir(::Type{<:SystemPath}) = Path(tempdir())
 
+# Pre-1.4 tempname didn't take any arguments.
+# We provide a system path dispatch for backward compatibility in these cases
+@static if VERSION < v"1.4"
+    Base.tempname(::Type{<:SystemtPath}; kwargs...) = Path(tempname())
+end
+
 function Base.tempname(parent::T; kwargs...) where {T<:SystemPath}
     return parse(T, tempname(string(parent); kwargs...))
 end

--- a/src/system.jl
+++ b/src/system.jl
@@ -235,12 +235,7 @@ end
 Base.touch(fp::T) where {T<:SystemPath} = parse(T, touch(string(fp)))
 
 Base.tempdir(::Type{<:SystemPath}) = Path(tempdir())
-
-# Pre-1.4 tempname didn't take any arguments.
-# We provide a system path dispatch for backward compatibility in these cases
-@static if VERSION < v"1.4"
-    Base.tempname(::Type{<:SystemtPath}; kwargs...) = Path(tempname())
-end
+Base.tempname(::Type{<:SystemPath}) = Path(tempname())
 
 function Base.tempname(parent::T; kwargs...) where {T<:SystemPath}
     return parse(T, tempname(string(parent); kwargs...))

--- a/test/testpkg.jl
+++ b/test/testpkg.jl
@@ -70,5 +70,6 @@ Base.read(fp::TestPath) = read(test2posix(fp))
 Base.write(fp::TestPath, x) = write(test2posix(fp), x)
 Base.chown(fp::TestPath, args...; kwargs...) = chown(test2posix(fp), args...; kwargs...)
 Base.chmod(fp::TestPath, args...; kwargs...) = chmod(test2posix(fp), args...; kwargs...)
+Base.tempdir(::Type{TestPath}) = posix2test(tempdir(PosixPath))
 
 end


### PR DESCRIPTION
 To support new 1.3+ kwargs (e.g., prefix, cleanup).
 
 NOTE: This should be a breaking release as we now require `tempdir` to be define for all path types.
 
 Closes #141 