### PR TITLE
Support join and sort kwargs to both readdir and readpath

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "FilePathsBase"
 uuid = "48062228-2e41-5def-b9a4-89aafe57970f"
 authors = ["Rory Finnegan"]
-version = "0.9.15"
+version = "0.9.16"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/path.jl
+++ b/src/path.jl
@@ -702,10 +702,16 @@ function Base.download(url::AbstractPath, localfile::AbstractString)
 end
 
 """
-    readpath(fp::P) where {P <: AbstractPath} -> Vector{P}
+    readpath(fp::P; join=true, sort=true) where {P <: AbstractPath} -> Vector{P}
 """
-function readpath(p::P)::Vector{P} where P <: AbstractPath
-    return P[join(p, f) for f in readdir(p)]
+function readpath(p::P; join=true, sort=true)::Vector{P} where P <: AbstractPath
+    @static if VERSION < v"1.4"
+        results = readdir(p)
+        sort && sort!(results)
+        return join ? joinpath.(p, results) : parse.(P, results)
+    else
+        return parse.(P, readdir(p; join=join, sort=sort))
+    end
 end
 
 """

--- a/src/system.jl
+++ b/src/system.jl
@@ -383,7 +383,7 @@ function Base.write(fp::SystemPath, x::Union{String, Vector{UInt8}}, mode="w")
     end
 end
 
-Base.readdir(fp::SystemPath) = readdir(string(fp))
+Base.readdir(fp::SystemPath; kwargs...) = readdir(string(fp); kwargs...)
 
 function Base.download(url::AbstractString, dest::T) where T<:SystemPath
     return parse(T, download(url, string(dest)))

--- a/test/testpkg.jl
+++ b/test/testpkg.jl
@@ -65,10 +65,17 @@ Base.cd(f::Function, fp::TestPath) = cd(f, test2posix(fp))
 Base.mkdir(fp::TestPath; kwargs...) = posix2test(mkdir(test2posix(fp); kwargs...))
 Base.symlink(src::TestPath, dest::TestPath; kwargs...) = symlink(test2posix(src), test2posix(dest); kwargs...)
 Base.rm(fp::TestPath; kwargs...) = rm(test2posix(fp); kwargs...)
-Base.readdir(fp::TestPath) = readdir(test2posix(fp))
 Base.read(fp::TestPath) = read(test2posix(fp))
 Base.write(fp::TestPath, x) = write(test2posix(fp), x)
 Base.chown(fp::TestPath, args...; kwargs...) = chown(test2posix(fp), args...; kwargs...)
 Base.chmod(fp::TestPath, args...; kwargs...) = chmod(test2posix(fp), args...; kwargs...)
+
+function Base.readdir(fp::TestPath; join=false, sort=true)
+    p = test2posix(fp)
+    results = readdir(p; join=join, sort=sort)
+    join || return results
+    # Awkward wrapper that converts the readdir output back to a TestPath string.
+    return string.(posix2test.(parse.(PosixPath, results)))
+end
 
 end

--- a/test/testpkg.jl
+++ b/test/testpkg.jl
@@ -72,10 +72,14 @@ Base.chmod(fp::TestPath, args...; kwargs...) = chmod(test2posix(fp), args...; kw
 
 function Base.readdir(fp::TestPath; join=false, sort=true)
     p = test2posix(fp)
-    results = readdir(p; join=join, sort=sort)
-    join || return results
-    # Awkward wrapper that converts the readdir output back to a TestPath string.
-    return string.(posix2test.(parse.(PosixPath, results)))
+    @static if VERSION < v"1.4"
+        return readdir(p)
+    else
+        results = readdir(p; join=join, sort=sort)
+        join || return results
+        # Awkward wrapper that converts the readdir output back to a TestPath string.
+        return string.(posix2test.(parse.(PosixPath, results)))
+    end
 end
 
 end


### PR DESCRIPTION
Closes #110 

```julia
julia> using FilePathsBase

julia> readdir(cwd())
12-element Vector{String}:
 ".DS_Store"
 ".git"
 ".github"
 ".gitignore"
 "LICENSE.md"
 "Manifest.toml"
 "Project.toml"
 "README.md"
 "docs"
 "foo.txt"
 "src"
 "test"

julia> readdir(cwd(); join=true)
12-element Vector{String}:
 "/Users/rory/repos/FilePathsBase.jl/.DS_Store"
 "/Users/rory/repos/FilePathsBase.jl/.git"
 "/Users/rory/repos/FilePathsBase.jl/.github"
 "/Users/rory/repos/FilePathsBase.jl/.gitignore"
 "/Users/rory/repos/FilePathsBase.jl/LICENSE.md"
 "/Users/rory/repos/FilePathsBase.jl/Manifest.toml"
 "/Users/rory/repos/FilePathsBase.jl/Project.toml"
 "/Users/rory/repos/FilePathsBase.jl/README.md"
 "/Users/rory/repos/FilePathsBase.jl/docs"
 "/Users/rory/repos/FilePathsBase.jl/foo.txt"
 "/Users/rory/repos/FilePathsBase.jl/src"
 "/Users/rory/repos/FilePathsBase.jl/test"

julia> readpath(cwd())
12-element Vector{PosixPath}:
 p"/Users/rory/repos/FilePathsBase.jl/.DS_Store"
 p"/Users/rory/repos/FilePathsBase.jl/.git"
 p"/Users/rory/repos/FilePathsBase.jl/.github"
 p"/Users/rory/repos/FilePathsBase.jl/.gitignore"
 p"/Users/rory/repos/FilePathsBase.jl/LICENSE.md"
 p"/Users/rory/repos/FilePathsBase.jl/Manifest.toml"
 p"/Users/rory/repos/FilePathsBase.jl/Project.toml"
 p"/Users/rory/repos/FilePathsBase.jl/README.md"
 p"/Users/rory/repos/FilePathsBase.jl/docs"
 p"/Users/rory/repos/FilePathsBase.jl/foo.txt"
 p"/Users/rory/repos/FilePathsBase.jl/src"
 p"/Users/rory/repos/FilePathsBase.jl/test"

julia> readpath(cwd(); join=false)
12-element Vector{PosixPath}:
 p".DS_Store"
 p".git"
 p".github"
 p".gitignore"
 p"LICENSE.md"
 p"Manifest.toml"
 p"Project.toml"
 p"README.md"
 p"docs"
 p"foo.txt"
 p"src"
 p"test"
```

The defaults maintain the current no-kwarg behaviour and type stability. We may unify `readpath` and `readdir` in the future now that `readdir` can do what we wanted `readpath` for. However, that would be a breaking release.