### PR TITLE
Only warn if gid or uid can't be found

### DIFF
--- a/src/libc.jl
+++ b/src/libc.jl
@@ -81,9 +81,13 @@ Base.show(io::IO, user::User) = print(io, "$(user.uid) ($(user.name))")
         ret = Libc.errno()
 
         systemerror(:getpwuid, !iszero(ret))
-        ps == C_NULL && throw(ArgumentError("User $uid not found."))
 
-        return User(ps)
+        if ps == C_NULL
+            @warn "User $uid not found."
+            return User("NA", uid, uid, "NA", "NA")
+        else
+            return User(ps)
+        end
     end
 
     User() = User(UInt(ccall(:geteuid, Cint, ())))
@@ -119,8 +123,12 @@ Base.show(io::IO, group::Group) = print(io, "$(group.gid) ($(group.name))")
         ret = Libc.errno()
 
         systemerror(:getgrgid, !iszero(ret))
-        gr == C_NULL && throw(ArgumentError("Group $gid not found."))
-        return Group(gr)
+        if gr == C_NULL
+            @warn "Group $gid not found."
+            return Group("NA", gid)
+        else
+            return Group(gr)
+        end
     end
 
     Group() = Group(UInt(ccall(:getegid, Cint, ())))

--- a/test/system.jl
+++ b/test/system.jl
@@ -293,6 +293,16 @@ ps = PathSet(; symlink=true)
                 @test g_int isa FilePathsBase.Group
                 @test u_int.uid isa Unsigned
                 @test g_int.gid isa Unsigned
+
+                # Non-existent user or group
+                u_int = FilePathsBase.User(UInt(9999))
+                g_int = FilePathsBase.Group(UInt(9999))
+                @test u_int isa FilePathsBase.User
+                @test g_int isa FilePathsBase.Group
+                @test u_int.uid == UInt(9999)
+                @test g_int.gid == UInt(9999)
+                @test u_int.name == "NA"
+                @test g_int.name == "NA"
             end
         end
 

--- a/test/system.jl
+++ b/test/system.jl
@@ -294,15 +294,17 @@ ps = PathSet(; symlink=true)
                 @test u_int.uid isa Unsigned
                 @test g_int.gid isa Unsigned
 
-                # Non-existent user or group
-                u_int = FilePathsBase.User(UInt(9999))
-                g_int = FilePathsBase.Group(UInt(9999))
-                @test u_int isa FilePathsBase.User
-                @test g_int isa FilePathsBase.Group
-                @test u_int.uid == UInt(9999)
-                @test g_int.gid == UInt(9999)
-                @test u_int.name == "NA"
-                @test g_int.name == "NA"
+                # Non-existent user or group on unix
+                if Sys.isunix()
+                    u_int = FilePathsBase.User(UInt(9999))
+                    g_int = FilePathsBase.Group(UInt(9999))
+                    @test u_int isa FilePathsBase.User
+                    @test g_int isa FilePathsBase.Group
+                    @test u_int.uid == UInt(9999)
+                    @test g_int.gid == UInt(9999)
+                    @test u_int.name == "NA"
+                    @test g_int.name == "NA"
+                end
             end
         end
 


### PR DESCRIPTION
I don't know if we want to do much else to handle missing cpasswd lookups, but this seems like a relatively safe way to pass the error down the line. I'm not sure if we want to do something similar for the string lookups?

Closes #130 