### PR TITLE
Add `readavailable(::FileBuffer)`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "FilePathsBase"
 uuid = "48062228-2e41-5def-b9a4-89aafe57970f"
 authors = ["Rory Finnegan"]
-version = "0.9.17"
+version = "0.9.18"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"

--- a/src/buffer.jl
+++ b/src/buffer.jl
@@ -35,6 +35,7 @@ end
 Base.isopen(buffer::FileBuffer) = isopen(buffer.io)
 Base.isreadable(buffer::FileBuffer) = buffer.read
 Base.iswritable(buffer::FileBuffer) = buffer.write
+Base.readavailable(buffer::FileBuffer) = read(buffer)
 Base.seek(buffer::FileBuffer, n::Integer) = (_read(buffer); seek(buffer.io, n))
 Base.skip(buffer::FileBuffer, n::Integer) = (_read(buffer); skip(buffer.io, n))
 Base.seekstart(buffer::FileBuffer) = seekstart(buffer.io)

--- a/test/buffer.jl
+++ b/test/buffer.jl
@@ -33,6 +33,8 @@ using FilePathsBase: FileBuffer
             close(io)
         end
 
+        @test readavailable(FileBuffer(p)) == readavailable(IOBuffer(read(p)))
+
         # issue #126: data on first read
         mktemp(SystemPath) do p, _
             write(p, "testing")


### PR DESCRIPTION
This adds a method for `FileBuffer`s to `readavailable` that precisely matches the behavior for `IOBuffer`s. This definition permits downstream niceties such as `CSV.read(::S3Path, ...)`.

I've also bumped the patch version as a separate commit.