### PR TITLE
Move aliases.jl file earlier

### DIFF
--- a/src/FilePathsBase.jl
+++ b/src/FilePathsBase.jl
@@ -120,6 +120,7 @@ Return a boolean as to whether the string `x` fits the specified the path type.
 """
 function ispathtype end
 
+include("aliases.jl")
 include("constants.jl")
 include("utils.jl")
 include("libc.jl")
@@ -127,7 +128,6 @@ include("mode.jl")
 include("status.jl")
 include("buffer.jl")
 include("path.jl")
-include("aliases.jl")
 include("system.jl")
 include("posix.jl")
 include("windows.jl")


### PR DESCRIPTION
Something has started causing errors loading the package, because `Base.join` gets resolved before `FilePathsBase.join` gets defined. This is probably a julia bug, but as a workaround, for now, move the aliases.jl file earlier to define `FilePathsBase.join` earlier in the package.