### PR TITLE
Correctly handle / in expanduser

### DIFF
--- a/src/posix.jl
+++ b/src/posix.jl
@@ -24,7 +24,7 @@ end
 function Base.expanduser(fp::PosixPath)::PosixPath
     p = fp.segments
 
-    if p[1] == "~"
+    if length(p) >= 1 && p[1] == "~"
         return length(p) > 1 ? joinpath(home(), p[2:end]...) : home()
     end
 

--- a/test/system.jl
+++ b/test/system.jl
@@ -360,6 +360,8 @@ ps = PathSet(; symlink=true)
         end
 
         @testset "expanduser" begin
+            @test expanduser(p"/") == p"/"
+
             fp = joinpath(cwd(), "..", "src", "FilePathsBase.jl")
             @test string(expanduser(fp)) == expanduser(string(fp))
 


### PR DESCRIPTION
`expanduser(p"/")` failed because `p"/"` doesn't have any segments. This fixes that.

I'd add a test as well, but I'm not sure where in the suite to put it...