### PR TITLE
Add uri extension

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -12,20 +12,24 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 [weakdeps]
 Mmap = "a63ad114-7e13-5084-954f-fe012c677804"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+URIs = "5c2747f8-b7ea-4ff2-ba2e-563bfd36b1d4"
 
 [extensions]
 FilePathsBaseMmapExt = "Mmap"
 FilePathsBaseTestExt = "Test"
+FilePathsBaseURIsExt = "URIs"
 
 [compat]
-julia = "1"
-Mmap = "<0.0.1, 1"
 Compat = "3.33, 4"
+Mmap = "<0.0.1, 1"
+URIs = "1.5.1"
+julia = "1"
 
 [extras]
 JLSO = "9da8a3cd-07a3-59c0-a743-3fdc52c30d11"
-Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Mmap = "a63ad114-7e13-5084-954f-fe012c677804"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+URIs = "5c2747f8-b7ea-4ff2-ba2e-563bfd36b1d4"
 
 [targets]
-test = ["JLSO", "Mmap", "Test"]
+test = ["JLSO", "Mmap", "Test", "URIs"]

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "FilePathsBase"
 uuid = "48062228-2e41-5def-b9a4-89aafe57970f"
 authors = ["Rory Finnegan"]
-version = "0.9.24"
+version = "0.10.0"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"

--- a/ext/FilePathsBaseURIsExt.jl
+++ b/ext/FilePathsBaseURIsExt.jl
@@ -1,0 +1,28 @@
+module FilePathsBaseURIsExt
+using URIs
+using FilePathsBase
+
+const absent = SubString("absent", 1, 0)
+
+function URIs.URI(p::AbstractPath; query=absent, fragment=absent)
+    if isempty(p.root)
+        throw(ArgumentError("$p is not an absolute path"))
+    end
+
+    b = IOBuffer()
+    print(b, "file://")
+
+    if !isempty(p.drive)
+        print(b, "/")
+        print(b, p.drive)
+    end
+
+    for s in p.segments
+        print(b, "/")
+        print(b, URIs.escapeuri(s))
+    end
+
+    return URIs.URI(URIs.URI(String(take!(b))); query=query, fragment=fragment)
+end
+
+end #module

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -17,6 +17,7 @@ include(p"testpkg.jl")
     include(p"mode.jl")
     include(p"buffer.jl")
     include(p"system.jl")
+    include(p"uris.jl")
 
     @static if Sys.isunix()
         # Test that our weird registered path works

--- a/test/uris.jl
+++ b/test/uris.jl
@@ -1,0 +1,10 @@
+using URIs
+using FilePathsBase
+
+@testset "URIs" begin
+    @test string(URIs.URI(p"/foo/bar")) == "file:///foo/bar"
+    @test string(URIs.URI(p"/foo foo/bar")) == "file:///foo%20foo/bar"
+    @test_throws ArgumentError URIs.URI(p"foo/bar")
+    @test string(URIs.URI(WindowsPath("C:\\foo\\bar"))) == "file:///C:/foo/bar"
+    @test string(URIs.URI(p"/foo/bar", query="querypart", fragment="fragmentpart")) == "file:///foo/bar?querypart#fragmentpart"
+end


### PR DESCRIPTION
Continuing from https://github.com/davidanthoff/Electron.jl/pull/140

This PR adds a package extension for URIs.jl. The implementation is taken from FilePaths.jl.

I think the version needs to be bumped so FilePaths.jl does not pull this in.